### PR TITLE
Fix CI/CD: Use -Help parameter instead of -? for help test

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -81,9 +81,10 @@ jobs:
         Write-Host "Testing script execution..."
 
         # Test help parameter
-        $helpOutput = & "./scripts/terracorder.ps1" -? 2>&1
+        $helpOutput = & "./scripts/terracorder.ps1" -Help 2>&1
         if ($LASTEXITCODE -ne 0) {
           Write-Error "Help parameter test failed"
+          Write-Host "Output: $helpOutput"
           exit 1
         }
 


### PR DESCRIPTION
- Changed help test from -? to -Help for clean exit code
- Script's -Help parameter properly exits with code 0
- PowerShell's -? doesn't exit cleanly, causing test failures
- Added output display on failure for better debugging